### PR TITLE
Prevent infinite loop during EthernetUdp::flush and Dhcp::parseDHCPResponse

### DIFF
--- a/src/Dhcp.cpp
+++ b/src/Dhcp.cpp
@@ -290,7 +290,15 @@ uint8_t DhcpClass::parseDHCPResponse(unsigned long responseTimeout, uint32_t& tr
 
         while (_dhcpUdpSocket.available() > 0) 
         {
-            switch (_dhcpUdpSocket.read()) 
+            int readByte = _dhcpUdpSocket.read();
+
+            // Udp read returned -1, no data available
+            // See EthernetUdp::flsh for background info
+            if (readByte < 0) {
+                break;
+            }
+
+            switch (readByte)
             {
                 case endOption :
                     break;
@@ -367,7 +375,10 @@ uint8_t DhcpClass::parseDHCPResponse(unsigned long responseTimeout, uint32_t& tr
                     // Skip over the rest of this option
                     while (opt_len--)
                     {
-                        _dhcpUdpSocket.read();
+                        readByte = _dhcpUdpSocket.read();
+                        if (readByte < 0) {
+                            break;
+                        }
                     }
                     break;
             }

--- a/src/EthernetUdp.cpp
+++ b/src/EthernetUdp.cpp
@@ -212,7 +212,12 @@ void EthernetUDP::flush()
 
   while (_remaining)
   {
-    read();
+    if (read() < 0) {
+      // In fact, this did fail, when _remaining > 0 and recv in read fails,
+      // So take that into account. When recv in read fails (that is, has
+      // nothing to read), simply reset _remaining.
+      _remaining = 0;
+    }
   }
 }
 


### PR DESCRIPTION
Follow up to #1 

We have the proposed workaround deployed to various devices (running 24/7) and they are free of the described »freezes« for months now.  
We also make use of these changes in our code for the new D21G boards — as I'm still unsure where the described issue originates from and I was afraid that code running on the new boards (connected to the Ethernet Module as well) could be affected too. If that is the case, the new Ethernet2 library should be patched accordingly.